### PR TITLE
embed hosted apps in shiny vignette

### DIFF
--- a/vignettes/shiny.Rmd
+++ b/vignettes/shiny.Rmd
@@ -41,7 +41,7 @@ The app is embedded below, followed by a walkthrough of the source code.
 knitr::include_app('https://qdread.shinyapps.io/ex-shiny-wide-data', height = '500px')
 ```
 
-If you aren't connected to the internet, the app might not display in the window above. You can view the app locally by running this line of code in your console:
+If you aren't connected to the internet, or if you loaded this vignette using `vignette('shiny', package = 'ggalluvial')` rather than `browseVignettes(package = 'ggalluvial')`, the app will not display in the window above. You can view the app locally by running this line of code in your console:
 
 ```{r run wide app locally, eval = FALSE}
 shiny::shinyAppDir(system.file("examples/ex-shiny-wide-data", package="ggalluvial"))
@@ -368,7 +368,7 @@ The app is embedded below.
 knitr::include_app('https://qdread.shinyapps.io/ex-shiny-long-data', height = '500px')
 ```
 
-Again, if you aren't connected to the internet, you can view the app locally by running this line of code in your console:
+Again, if the app doesn't display in the window above for whatever reason, you can view it locally by running this line of code in your console:
 
 ```{r run long app locally, eval = FALSE}
 shiny::shinyAppDir(system.file("examples/ex-shiny-long-data", package="ggalluvial"))

--- a/vignettes/shiny.Rmd
+++ b/vignettes/shiny.Rmd
@@ -38,10 +38,13 @@ Hovering over and clicking on alluvia are more difficult because the shapes of t
 The app is embedded below, followed by a walkthrough of the source code.
 
 ```{r wide app, echo = FALSE}
-shiny::shinyAppDir(
-  system.file("examples/ex-shiny-wide-data", package="ggalluvial"),
-  options = list(width = 800, height = 500)
-)
+knitr::include_app('https://qdread.shinyapps.io/ex-shiny-wide-data', height = '500px')
+```
+
+If you aren't connected to the internet, the app might not display in the window above. You can view the app locally by running this line of code in your console:
+
+```{r run wide app locally, eval = FALSE}
+shiny::shinyAppDir(system.file("examples/ex-shiny-wide-data", package="ggalluvial"))
 ```
 
 ## Structure of the example app
@@ -362,10 +365,13 @@ The `vaccinations` dataset is used for long-format alluvial data. The app is emb
 The app is embedded below.
 
 ```{r long app, echo = FALSE}
-shiny::shinyAppDir(
-  system.file("examples/ex-shiny-long-data", package="ggalluvial"),
-  options = list(width = 800, height = 500)
-)
+knitr::include_app('https://qdread.shinyapps.io/ex-shiny-long-data', height = '500px')
+```
+
+Again, if you aren't connected to the internet, you can view the app locally by running this line of code in your console:
+
+```{r run long app locally, eval = FALSE}
+shiny::shinyAppDir(system.file("examples/ex-shiny-long-data", package="ggalluvial"))
 ```
 
 ## Conclusion


### PR DESCRIPTION
Resolves #82  . It was simpler than I thought! Hopefully the apps will be hosted more or less indefinitely on the shinyapps.io server. If not, we will have to come up with a new solution.

Summary of proposed changes:
- uses `knitr::include_app()` to embed the apps in the vignette, I think it's fine to use this as the vignette rendering engine already depends on knitr so this adds no new dependencies.
- now this should work once the pkgdown site is built, as well as with `browseVignettes()`. It does not work with `vignette()` though. I've asked a [question about this on rstudio forum](https://community.rstudio.com/t/shiny-app-in-vignette-works-with-browsevignettes-but-not-vignette-in-rstudio/101814). If I get an answer I will update further but I think this is good for now.
