### PR TITLE
Change dimensions of apps and put legends at the bottom

### DIFF
--- a/docs/articles/shiny.html
+++ b/docs/articles/shiny.html
@@ -39,7 +39,7 @@
       <ul class="nav navbar-nav">
 <li>
   <a href="../index.html">
-    <span class="fas fa-home fa-lg"></span>
+    <span class="fas fa fas fa-home fa-lg"></span>
      
   </a>
 </li>
@@ -74,7 +74,7 @@
 <ul class="nav navbar-nav navbar-right">
 <li>
   <a href="https://github.com/corybrunson/ggalluvial/">
-    <span class="fab fa-github fa-lg"></span>
+    <span class="fab fa fab fa-github fa-lg"></span>
      
   </a>
 </li>
@@ -88,7 +88,7 @@
 
       
 
-      </header><script src="shiny_files/header-attrs-2.8/header-attrs.js"></script><div class="row">
+      </header><div class="row">
   <div class="col-md-9 contents">
     <div class="page-header toc-ignore">
       <h1 data-toc-skip>Tooltips for ggalluvial plots in Shiny apps</h1>
@@ -124,11 +124,11 @@
 <h2 class="hasAnchor">
 <a href="#section-app-with-wide-format-alluvial-data" class="anchor"></a>App with wide-format alluvial data</h2>
 <p>The app is embedded below, followed by a walkthrough of the source code.</p>
-<iframe src="https://qdread.shinyapps.io/ex-shiny-wide-data?showcase=0" width="576" height="500px">
+<iframe src="https://qdread.shinyapps.io/ex-shiny-wide-data?showcase=0" width="576" height="650px">
 </iframe>
 <p>If you aren’t connected to the internet, or if you loaded this vignette using <code><a href="../articles/shiny.html">vignette('shiny', package = 'ggalluvial')</a></code> rather than <code><a href="https://rdrr.io/r/utils/browseVignettes.html">browseVignettes(package = 'ggalluvial')</a></code>, the app will not display in the window above. You can view the app locally by running this line of code in your console:</p>
 <div class="sourceCode" id="section-cb1"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span class="fu">shiny</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/shiny/man/shinyApp.html">shinyAppDir</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/system.file.html">system.file</a></span><span class="op">(</span><span class="st">"examples/ex-shiny-wide-data"</span>, package<span class="op">=</span><span class="st">"ggalluvial"</span><span class="op">)</span><span class="op">)</span></code></pre></div>
+<code class="sourceCode R"><span class="fu">shiny</span><span class="fu">::</span><span class="fu"><a href="https://shiny.rstudio.com/reference/shiny/latest/shinyApp.html">shinyAppDir</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/system.file.html">system.file</a></span><span class="op">(</span><span class="st">"examples/ex-shiny-wide-data"</span>, package<span class="op">=</span><span class="st">"ggalluvial"</span><span class="op">)</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="section-structure-of-the-example-app" class="section level2">
 <h2 class="hasAnchor">
@@ -136,48 +136,48 @@
 <p>Here, we will go over each section of the code in detail. The full source code is included in the package’s <code>examples</code> directory.</p>
 <p>The app first (1) loads the data and (2) builds the plot. Then, (3) information is extracted from the built plot object to (4) manually recalculate the coordinates of the polygons that make up the plot. Internally, <strong>ggalluvial</strong> uses the <strong>grid</strong> package to draw the polygons, so the next steps are (5) to define the minima and maxima of the x and y axes in <strong>grid</strong> units and the units that appear on the plot’s coordinate system, and (6) to convert the polygon coordinates from <strong>grid</strong> units plot units. Next, the user interface is defined, including output of (7) the plot image and (8) the tooltip. The final block of code is the server function, which first (9) renders the plot. Finally, the tooltip is defined. This includes (10) logic to determine whether the mouse cursor is inside the plot panel, then (11) whether it is hovering over a stratum, (12) an alluvium, or neither, based on the mouse coordinates provided by Shiny. If the mouse is hovering over a plot element, the app finds appropriate information and prints it in a small “tooltip” box next to the mouse cursor (11b and 12b).</p>
 <p>This is the structure of the app in pseudocode.</p>
-<div class="sourceCode" id="section-cb2"><pre class="sourceCode r"><code class="sourceCode r"><span id="section-cb2-1"><a href="#section-cb2-1" aria-hidden="true" tabindex="-1"></a><span class="st">'&lt;(1) Load data.&gt;'</span></span>
-<span id="section-cb2-2"><a href="#section-cb2-2" aria-hidden="true" tabindex="-1"></a></span>
-<span id="section-cb2-3"><a href="#section-cb2-3" aria-hidden="true" tabindex="-1"></a><span class="st">'&lt;(2) Create "ggplot" object for alluvial plot and build it.&gt;'</span></span>
-<span id="section-cb2-4"><a href="#section-cb2-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="section-cb2-5"><a href="#section-cb2-5" aria-hidden="true" tabindex="-1"></a><span class="st">'&lt;(3) Extract data from built plot object used to create alluvium polygons.&gt;'</span></span>
-<span id="section-cb2-6"><a href="#section-cb2-6" aria-hidden="true" tabindex="-1"></a></span>
-<span id="section-cb2-7"><a href="#section-cb2-7" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> (polygon <span class="cf">in</span> polygons) {</span>
-<span id="section-cb2-8"><a href="#section-cb2-8" aria-hidden="true" tabindex="-1"></a>     <span class="st">'&lt;(4) Use polygon splines to generate coordinates of alluvium boundaries.&gt;'</span></span>
-<span id="section-cb2-9"><a href="#section-cb2-9" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="section-cb2-10"><a href="#section-cb2-10" aria-hidden="true" tabindex="-1"></a></span>
-<span id="section-cb2-11"><a href="#section-cb2-11" aria-hidden="true" tabindex="-1"></a><span class="st">'&lt;(5) Define range of coordinates in grid units and plot units.&gt;'</span></span>
-<span id="section-cb2-12"><a href="#section-cb2-12" aria-hidden="true" tabindex="-1"></a></span>
-<span id="section-cb2-13"><a href="#section-cb2-13" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> (polygon <span class="cf">in</span> polygons) {    </span>
-<span id="section-cb2-14"><a href="#section-cb2-14" aria-hidden="true" tabindex="-1"></a>     <span class="st">'&lt;(6) Convert coordinates from grid units to plot units.&gt;'</span></span>
-<span id="section-cb2-15"><a href="#section-cb2-15" aria-hidden="true" tabindex="-1"></a>}</span>
-<span id="section-cb2-16"><a href="#section-cb2-16" aria-hidden="true" tabindex="-1"></a></span>
-<span id="section-cb2-17"><a href="#section-cb2-17" aria-hidden="true" tabindex="-1"></a>ui <span class="ot">&lt;-</span> <span class="fu">fluidPage</span>(</span>
-<span id="section-cb2-18"><a href="#section-cb2-18" aria-hidden="true" tabindex="-1"></a>     <span class="st">'&lt;(7) Output plot with hovering enabled.&gt;'</span></span>
-<span id="section-cb2-19"><a href="#section-cb2-19" aria-hidden="true" tabindex="-1"></a>     </span>
-<span id="section-cb2-20"><a href="#section-cb2-20" aria-hidden="true" tabindex="-1"></a>     <span class="st">'&lt;(8) Output tooltip.&gt;'</span></span>
-<span id="section-cb2-21"><a href="#section-cb2-21" aria-hidden="true" tabindex="-1"></a>)</span>
-<span id="section-cb2-22"><a href="#section-cb2-22" aria-hidden="true" tabindex="-1"></a></span>
-<span id="section-cb2-23"><a href="#section-cb2-23" aria-hidden="true" tabindex="-1"></a></span>
-<span id="section-cb2-24"><a href="#section-cb2-24" aria-hidden="true" tabindex="-1"></a>server <span class="ot">&lt;-</span> <span class="cf">function</span>(input, output, session) {</span>
-<span id="section-cb2-25"><a href="#section-cb2-25" aria-hidden="true" tabindex="-1"></a>  </span>
-<span id="section-cb2-26"><a href="#section-cb2-26" aria-hidden="true" tabindex="-1"></a>  output<span class="sc">$</span>alluvial_plot <span class="ot">&lt;-</span> <span class="fu">renderPlot</span>({</span>
-<span id="section-cb2-27"><a href="#section-cb2-27" aria-hidden="true" tabindex="-1"></a>    <span class="st">'&lt;(9) Render the plot.&gt;'</span></span>
-<span id="section-cb2-28"><a href="#section-cb2-28" aria-hidden="true" tabindex="-1"></a>  })</span>
-<span id="section-cb2-29"><a href="#section-cb2-29" aria-hidden="true" tabindex="-1"></a>  </span>
-<span id="section-cb2-30"><a href="#section-cb2-30" aria-hidden="true" tabindex="-1"></a>  output<span class="sc">$</span>tooltip <span class="ot">&lt;-</span> <span class="fu">renderText</span>({</span>
-<span id="section-cb2-31"><a href="#section-cb2-31" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (<span class="st">'&lt;(10) mouse cursor is within the plot panel&gt;'</span>) {</span>
-<span id="section-cb2-32"><a href="#section-cb2-32" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> (<span class="st">'&lt;(11) mouse cursor is within a stratum box&gt;'</span>) {</span>
-<span id="section-cb2-33"><a href="#section-cb2-33" aria-hidden="true" tabindex="-1"></a>        <span class="st">'&lt;(11b) Render stratum tooltip.&gt;'</span></span>
-<span id="section-cb2-34"><a href="#section-cb2-34" aria-hidden="true" tabindex="-1"></a>      } <span class="cf">else</span> {</span>
-<span id="section-cb2-35"><a href="#section-cb2-35" aria-hidden="true" tabindex="-1"></a>        <span class="cf">if</span> (<span class="st">'&lt;(12) mouse cursor is within an alluvium polygon&gt;'</span>) {</span>
-<span id="section-cb2-36"><a href="#section-cb2-36" aria-hidden="true" tabindex="-1"></a>          <span class="st">'&lt;(12b) Render alluvium tooltip.&gt;'</span></span>
-<span id="section-cb2-37"><a href="#section-cb2-37" aria-hidden="true" tabindex="-1"></a>        }</span>
-<span id="section-cb2-38"><a href="#section-cb2-38" aria-hidden="true" tabindex="-1"></a>      }</span>
-<span id="section-cb2-39"><a href="#section-cb2-39" aria-hidden="true" tabindex="-1"></a>    }</span>
-<span id="section-cb2-40"><a href="#section-cb2-40" aria-hidden="true" tabindex="-1"></a>  })</span>
-<span id="section-cb2-41"><a href="#section-cb2-41" aria-hidden="true" tabindex="-1"></a>  </span>
-<span id="section-cb2-42"><a href="#section-cb2-42" aria-hidden="true" tabindex="-1"></a>}</span></code></pre></div>
+<div class="sourceCode" id="section-cb2"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb2-1" title="1"><span class="st">'&lt;(1) Load data.&gt;'</span></a>
+<a class="sourceLine" id="cb2-2" title="2"></a>
+<a class="sourceLine" id="cb2-3" title="3"><span class="st">'&lt;(2) Create "ggplot" object for alluvial plot and build it.&gt;'</span></a>
+<a class="sourceLine" id="cb2-4" title="4"></a>
+<a class="sourceLine" id="cb2-5" title="5"><span class="st">'&lt;(3) Extract data from built plot object used to create alluvium polygons.&gt;'</span></a>
+<a class="sourceLine" id="cb2-6" title="6"></a>
+<a class="sourceLine" id="cb2-7" title="7"><span class="cf">for</span> (polygon <span class="cf">in</span> polygons) {</a>
+<a class="sourceLine" id="cb2-8" title="8">     <span class="st">'&lt;(4) Use polygon splines to generate coordinates of alluvium boundaries.&gt;'</span></a>
+<a class="sourceLine" id="cb2-9" title="9">}</a>
+<a class="sourceLine" id="cb2-10" title="10"></a>
+<a class="sourceLine" id="cb2-11" title="11"><span class="st">'&lt;(5) Define range of coordinates in grid units and plot units.&gt;'</span></a>
+<a class="sourceLine" id="cb2-12" title="12"></a>
+<a class="sourceLine" id="cb2-13" title="13"><span class="cf">for</span> (polygon <span class="cf">in</span> polygons) {    </a>
+<a class="sourceLine" id="cb2-14" title="14">     <span class="st">'&lt;(6) Convert coordinates from grid units to plot units.&gt;'</span></a>
+<a class="sourceLine" id="cb2-15" title="15">}</a>
+<a class="sourceLine" id="cb2-16" title="16"></a>
+<a class="sourceLine" id="cb2-17" title="17">ui &lt;-<span class="st"> </span><span class="kw">fluidPage</span>(</a>
+<a class="sourceLine" id="cb2-18" title="18">     <span class="st">'&lt;(7) Output plot with hovering enabled.&gt;'</span></a>
+<a class="sourceLine" id="cb2-19" title="19">     </a>
+<a class="sourceLine" id="cb2-20" title="20">     <span class="st">'&lt;(8) Output tooltip.&gt;'</span></a>
+<a class="sourceLine" id="cb2-21" title="21">)</a>
+<a class="sourceLine" id="cb2-22" title="22"></a>
+<a class="sourceLine" id="cb2-23" title="23"></a>
+<a class="sourceLine" id="cb2-24" title="24">server &lt;-<span class="st"> </span><span class="cf">function</span>(input, output, session) {</a>
+<a class="sourceLine" id="cb2-25" title="25">  </a>
+<a class="sourceLine" id="cb2-26" title="26">  output<span class="op">$</span>alluvial_plot &lt;-<span class="st"> </span><span class="kw">renderPlot</span>({</a>
+<a class="sourceLine" id="cb2-27" title="27">    <span class="st">'&lt;(9) Render the plot.&gt;'</span></a>
+<a class="sourceLine" id="cb2-28" title="28">  })</a>
+<a class="sourceLine" id="cb2-29" title="29">  </a>
+<a class="sourceLine" id="cb2-30" title="30">  output<span class="op">$</span>tooltip &lt;-<span class="st"> </span><span class="kw">renderText</span>({</a>
+<a class="sourceLine" id="cb2-31" title="31">    <span class="cf">if</span> (<span class="st">'&lt;(10) mouse cursor is within the plot panel&gt;'</span>) {</a>
+<a class="sourceLine" id="cb2-32" title="32">      <span class="cf">if</span> (<span class="st">'&lt;(11) mouse cursor is within a stratum box&gt;'</span>) {</a>
+<a class="sourceLine" id="cb2-33" title="33">        <span class="st">'&lt;(11b) Render stratum tooltip.&gt;'</span></a>
+<a class="sourceLine" id="cb2-34" title="34">      } <span class="cf">else</span> {</a>
+<a class="sourceLine" id="cb2-35" title="35">        <span class="cf">if</span> (<span class="st">'&lt;(12) mouse cursor is within an alluvium polygon&gt;'</span>) {</a>
+<a class="sourceLine" id="cb2-36" title="36">          <span class="st">'&lt;(12b) Render alluvium tooltip.&gt;'</span></a>
+<a class="sourceLine" id="cb2-37" title="37">        }</a>
+<a class="sourceLine" id="cb2-38" title="38">      }</a>
+<a class="sourceLine" id="cb2-39" title="39">    }</a>
+<a class="sourceLine" id="cb2-40" title="40">  })</a>
+<a class="sourceLine" id="cb2-41" title="41">  </a>
+<a class="sourceLine" id="cb2-42" title="42">}</a></code></pre></div>
 <div id="section-loading-data" class="section level3">
 <h3 class="hasAnchor">
 <a href="#section-loading-data" class="anchor"></a>Loading data</h3>
@@ -208,12 +208,15 @@
   <span class="fu">geom_label</span><span class="op">(</span><span class="fu">aes</span><span class="op">(</span>label <span class="op">=</span> <span class="fu">after_stat</span><span class="op">(</span><span class="va">stratum</span><span class="op">)</span><span class="op">)</span>, 
              stat <span class="op">=</span> <span class="st">"stratum"</span>, 
              reverse <span class="op">=</span> <span class="cn">TRUE</span>, 
-             size <span class="op">=</span> <span class="fu">rel</span><span class="op">(</span><span class="fl">3</span><span class="op">)</span><span class="op">)</span> <span class="op">+</span> 
+             size <span class="op">=</span> <span class="fu">rel</span><span class="op">(</span><span class="fl">2</span><span class="op">)</span><span class="op">)</span> <span class="op">+</span> 
   <span class="fu">theme_bw</span><span class="op">(</span><span class="op">)</span> <span class="op">+</span>
   <span class="fu">scale_fill_brewer</span><span class="op">(</span>type <span class="op">=</span> <span class="st">"qual"</span>, palette <span class="op">=</span> <span class="st">"Set1"</span><span class="op">)</span> <span class="op">+</span>
   <span class="fu">scale_x_discrete</span><span class="op">(</span>limits <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="st">"Gender"</span>, <span class="st">"Dept"</span><span class="op">)</span>, expand <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="fl">.05</span>, <span class="fl">.05</span><span class="op">)</span><span class="op">)</span> <span class="op">+</span>
   <span class="fu">scale_y_continuous</span><span class="op">(</span>expand <span class="op">=</span> <span class="fu"><a href="https://rdrr.io/r/base/c.html">c</a></span><span class="op">(</span><span class="fl">0</span>, <span class="fl">0</span><span class="op">)</span><span class="op">)</span> <span class="op">+</span>
-  <span class="fu">ggtitle</span><span class="op">(</span><span class="st">"UC Berkeley admissions and rejections, by sex and department"</span><span class="op">)</span>
+  <span class="fu">ggtitle</span><span class="op">(</span><span class="st">"UC Berkeley admissions and rejections"</span>, <span class="st">"by sex and department"</span><span class="op">)</span> <span class="op">+</span>
+  <span class="fu">theme</span><span class="op">(</span>plot.title <span class="op">=</span> <span class="fu">element_text</span><span class="op">(</span>size <span class="op">=</span> <span class="fu">rel</span><span class="op">(</span><span class="fl">1</span><span class="op">)</span><span class="op">)</span>,
+        plot.subtitle <span class="op">=</span> <span class="fu">element_text</span><span class="op">(</span>size <span class="op">=</span> <span class="fu">rel</span><span class="op">(</span><span class="fl">1</span><span class="op">)</span><span class="op">)</span>,
+        legend.position <span class="op">=</span> <span class="st">'bottom'</span><span class="op">)</span>
 
 <span class="co"># Build the plot. </span>
 <span class="va">pbuilt</span> <span class="op">&lt;-</span> <span class="fu">ggplot_build</span><span class="op">(</span><span class="va">p</span><span class="op">)</span></code></pre></div>
@@ -278,7 +281,7 @@
 <code class="sourceCode R"><span class="va">ui</span> <span class="op">&lt;-</span> <span class="fu">fluidPage</span><span class="op">(</span>
   <span class="fu">fluidRow</span><span class="op">(</span><span class="va">tags</span><span class="op">$</span><span class="fu">div</span><span class="op">(</span>
     style <span class="op">=</span> <span class="st">"position: relative;"</span>,
-    <span class="fu">plotOutput</span><span class="op">(</span><span class="st">"alluvial_plot"</span>, height <span class="op">=</span> <span class="st">"500px"</span>, 
+    <span class="fu">plotOutput</span><span class="op">(</span><span class="st">"alluvial_plot"</span>, height <span class="op">=</span> <span class="st">"650px"</span>, 
                hover <span class="op">=</span> <span class="fu">hoverOpts</span><span class="op">(</span>id <span class="op">=</span> <span class="st">"plot_hover"</span><span class="op">)</span>
                <span class="op">)</span>,
     <span class="fu">htmlOutput</span><span class="op">(</span><span class="st">"tooltip"</span><span class="op">)</span><span class="op">)</span><span class="op">)</span>
@@ -300,22 +303,22 @@
 <code class="sourceCode R"><span class="va">output</span><span class="op">$</span><span class="va">alluvial_plot</span> <span class="op">&lt;-</span> <span class="fu">renderPlot</span><span class="op">(</span><span class="va">p</span>, res <span class="op">=</span> <span class="fl">200</span><span class="op">)</span></code></pre></div>
 <p>Next, we define the tooltip with a <code>renderText()</code> expression. Within that expression, we first extract the cursor’s plot coordinates from the user input. We determine whether the cursor is hovering over a stratum and if so, display the appropriate tooltip.</p>
 <div class="figure">
-<img src="https://raw.githubusercontent.com/corybrunson/ggalluvial/main/vignettes/img/hover_stratum.png" alt=""><p class="caption">screenshot of tooltip on stratum</p>
+<img src="https://raw.githubusercontent.com/corybrunson/ggalluvial/main/vignettes/img/hover_stratum.png" alt="screenshot of tooltip on stratum"><p class="caption">screenshot of tooltip on stratum</p>
 </div>
 <p>If the mouse cursor is not hovering over a stratum, we determine whether it is hovering over an alluvium polygon and if so, display different information in the tooltip.</p>
 <div class="figure">
-<img src="https://raw.githubusercontent.com/corybrunson/ggalluvial/main/vignettes/img/hover_alluvium.png" alt=""><p class="caption">screenshot of tooltip on alluvium</p>
+<img src="https://raw.githubusercontent.com/corybrunson/ggalluvial/main/vignettes/img/hover_alluvium.png" alt="screenshot of tooltip on alluvium"><p class="caption">screenshot of tooltip on alluvium</p>
 </div>
 <p>If the mouse cursor is hovering over an empty region of the plot, <code>renderText()</code> returns nothing and no tooltip appears.</p>
 <div class="figure">
-<img src="https://raw.githubusercontent.com/corybrunson/ggalluvial/main/vignettes/img/hover_empty_area.png" alt=""><p class="caption">screenshot of cursor over empty region</p>
+<img src="https://raw.githubusercontent.com/corybrunson/ggalluvial/main/vignettes/img/hover_empty_area.png" alt="screenshot of cursor over empty region"><p class="caption">screenshot of cursor over empty region</p>
 </div>
 <p>Let’s take a deeper dive into the logic used to determine the text that appears in the tooltip.</p>
 <p>First, we check whether the cursor is inside the plot panel. If it is not, the element <code>plot_hover</code> of the input will be <code>NULL</code>. In that case <code>renderText()</code> will return nothing and no tooltip will appear.</p>
-<div class="sourceCode" id="section-cb11"><pre class="sourceCode r"><code class="sourceCode r"><span id="section-cb11-1"><a href="#section-cb11-1" aria-hidden="true" tabindex="-1"></a>output<span class="sc">$</span>tooltip <span class="ot">&lt;-</span> <span class="fu">renderText</span>(</span>
-<span id="section-cb11-2"><a href="#section-cb11-2" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span>(<span class="sc">!</span><span class="fu">is.null</span>(input<span class="sc">$</span>plot_hover)) { ... }</span>
-<span id="section-cb11-3"><a href="#section-cb11-3" aria-hidden="true" tabindex="-1"></a>  ...</span>
-<span id="section-cb11-4"><a href="#section-cb11-4" aria-hidden="true" tabindex="-1"></a>)</span></code></pre></div>
+<div class="sourceCode" id="section-cb11"><pre class="sourceCode r"><code class="sourceCode r"><a class="sourceLine" id="cb11-1" title="1">output<span class="op">$</span>tooltip &lt;-<span class="st"> </span><span class="kw">renderText</span>(</a>
+<a class="sourceLine" id="cb11-2" title="2">  <span class="cf">if</span>(<span class="op">!</span><span class="kw">is.null</span>(input<span class="op">$</span>plot_hover)) { ... }</a>
+<a class="sourceLine" id="cb11-3" title="3">  ...</a>
+<a class="sourceLine" id="cb11-4" title="4">)</a></code></pre></div>
 <div id="section-hovering-over-a-stratum" class="section level4">
 <h4 class="hasAnchor">
 <a href="#section-hovering-over-a-stratum" class="anchor"></a>Hovering over a stratum</h4>
@@ -394,11 +397,11 @@
 <a href="#section-app-with-long-format-alluvial-data" class="anchor"></a>App with long-format alluvial data</h2>
 <p>The <code>vaccinations</code> dataset is used for long-format alluvial data. The app is embedded at the bottom of this document, but we don’t need to walk through the source code because it’s almost identical to the code above. The output of <code>ggplot_build()</code> that is used to find the polygon coordinates and information for the tooltips has a consistent structure regardless of the initial format of the input data. Therefore, the calculation of polygon coordinates, user interface, and server functions of the two apps are identical. The only difference is in the initial creation of the <code>ggplot()</code> object. Refer back to the <a href="ggalluvial.html">primary vignette</a> for several example plots made both with long and with wide data.</p>
 <p>The app is embedded below.</p>
-<iframe src="https://qdread.shinyapps.io/ex-shiny-long-data?showcase=0" width="576" height="500px">
+<iframe src="https://qdread.shinyapps.io/ex-shiny-long-data?showcase=0" width="576" height="650px">
 </iframe>
 <p>Again, if the app doesn’t display in the window above for whatever reason, you can view it locally by running this line of code in your console:</p>
 <div class="sourceCode" id="section-cb20"><pre class="downlit sourceCode r">
-<code class="sourceCode R"><span class="fu">shiny</span><span class="fu">::</span><span class="fu"><a href="https://rdrr.io/pkg/shiny/man/shinyApp.html">shinyAppDir</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/system.file.html">system.file</a></span><span class="op">(</span><span class="st">"examples/ex-shiny-long-data"</span>, package<span class="op">=</span><span class="st">"ggalluvial"</span><span class="op">)</span><span class="op">)</span></code></pre></div>
+<code class="sourceCode R"><span class="fu">shiny</span><span class="fu">::</span><span class="fu"><a href="https://shiny.rstudio.com/reference/shiny/latest/shinyApp.html">shinyAppDir</a></span><span class="op">(</span><span class="fu"><a href="https://rdrr.io/r/base/system.file.html">system.file</a></span><span class="op">(</span><span class="st">"examples/ex-shiny-long-data"</span>, package<span class="op">=</span><span class="st">"ggalluvial"</span><span class="op">)</span><span class="op">)</span></code></pre></div>
 </div>
 <div id="section-conclusion" class="section level2">
 <h2 class="hasAnchor">

--- a/inst/examples/ex-shiny-long-data/app.R
+++ b/inst/examples/ex-shiny-long-data/app.R
@@ -28,7 +28,8 @@ p <- ggplot(vaccinations,
   theme_bw() +
   theme(legend.position = "none") +
   ggtitle("Vaccination responses on three surveys") +
-  theme(plot.title = element_text(size = rel(1)))
+  theme(plot.title = element_text(size = rel(1)),
+        legend.position = 'bottom')
 
 # Build the plot. Use global assignment so that this object is accessible
 # later.
@@ -89,7 +90,7 @@ polygon_coords <- lapply(xspline_points, function(pts) {
 ui <- fluidPage(
   fluidRow(tags$div(
     style = "position: relative;",
-    plotOutput("alluvial_plot", height = "500px", 
+    plotOutput("alluvial_plot", height = "650px", 
                hover = hoverOpts(id = "plot_hover")
     ),
     htmlOutput("tooltip")))

--- a/inst/examples/ex-shiny-wide-data/app.R
+++ b/inst/examples/ex-shiny-wide-data/app.R
@@ -29,7 +29,8 @@ p <- ggplot(ucb_admissions,
   scale_y_continuous(expand = c(0, 0)) +
   ggtitle("UC Berkeley admissions and rejections", "by sex and department") +
   theme(plot.title = element_text(size = rel(1)),
-        plot.subtitle = element_text(size = rel(1)))
+        plot.subtitle = element_text(size = rel(1)),
+        legend.position = 'bottom')
 
 # Build the plot. 
 pbuilt <- ggplot_build(p)
@@ -89,7 +90,7 @@ polygon_coords <- lapply(xspline_points, function(pts) {
 ui <- fluidPage(
   fluidRow(tags$div(
     style = "position: relative;",
-    plotOutput("alluvial_plot", height = "500px", 
+    plotOutput("alluvial_plot", height = "650px", 
                hover = hoverOpts(id = "plot_hover")
     ),
     htmlOutput("tooltip")))

--- a/vignettes/shiny.Rmd
+++ b/vignettes/shiny.Rmd
@@ -38,7 +38,7 @@ Hovering over and clicking on alluvia are more difficult because the shapes of t
 The app is embedded below, followed by a walkthrough of the source code.
 
 ```{r wide app, echo = FALSE}
-knitr::include_app('https://qdread.shinyapps.io/ex-shiny-wide-data', height = '500px')
+knitr::include_app('https://qdread.shinyapps.io/ex-shiny-wide-data', height = '650px')
 ```
 
 If you aren't connected to the internet, or if you loaded this vignette using `vignette('shiny', package = 'ggalluvial')` rather than `browseVignettes(package = 'ggalluvial')`, the app will not display in the window above. You can view the app locally by running this line of code in your console:
@@ -135,12 +135,15 @@ p <- ggplot(ucb_admissions,
   geom_label(aes(label = after_stat(stratum)), 
              stat = "stratum", 
              reverse = TRUE, 
-             size = rel(3)) + 
+             size = rel(2)) + 
   theme_bw() +
   scale_fill_brewer(type = "qual", palette = "Set1") +
   scale_x_discrete(limits = c("Gender", "Dept"), expand = c(.05, .05)) +
   scale_y_continuous(expand = c(0, 0)) +
-  ggtitle("UC Berkeley admissions and rejections, by sex and department")
+  ggtitle("UC Berkeley admissions and rejections", "by sex and department") +
+  theme(plot.title = element_text(size = rel(1)),
+        plot.subtitle = element_text(size = rel(1)),
+        legend.position = 'bottom')
 
 # Build the plot. 
 pbuilt <- ggplot_build(p)
@@ -217,7 +220,7 @@ The app includes a minimal user interface with two output elements.
 ui <- fluidPage(
   fluidRow(tags$div(
     style = "position: relative;",
-    plotOutput("alluvial_plot", height = "500px", 
+    plotOutput("alluvial_plot", height = "650px", 
                hover = hoverOpts(id = "plot_hover")
                ),
     htmlOutput("tooltip")))
@@ -365,7 +368,7 @@ The `vaccinations` dataset is used for long-format alluvial data. The app is emb
 The app is embedded below.
 
 ```{r long app, echo = FALSE}
-knitr::include_app('https://qdread.shinyapps.io/ex-shiny-long-data', height = '500px')
+knitr::include_app('https://qdread.shinyapps.io/ex-shiny-long-data', height = '650px')
 ```
 
 Again, if the app doesn't display in the window above for whatever reason, you can view it locally by running this line of code in your console:


### PR DESCRIPTION
Resolves issue of app windows not having proper dimensions. I have already deployed the apps with the legends on bottom to the shiny server.

Summary of proposed changes:
- Still using knitr::include_app, not iframe, but increased the height to 650px for each one
- Legends are placed at bottom in apps. This change also reflected in apps source code in inst folder, and in the vignette itself
